### PR TITLE
Update Nginx to version 1.21.1

### DIFF
--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -47,7 +47,6 @@ jobs:
           file: ./Dockerfile
           platforms: |
             linux/amd64
-            linux/386
             linux/arm64
             linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.21.0-alpine AS base
+FROM nginx:1.21.1-alpine AS base
 
 # Create a builder image.
 FROM base AS builder


### PR DESCRIPTION
This change also drops support for the i386 arch for Alpine.
This is because Alpine seems to have stopped building all the necessary
stuff for 32 bit systems, so our parent image cannot be built.

More info:
https://github.com/JonasAlfredsson/docker-nginx-certbot/issues/77
https://github.com/nginxinc/docker-nginx/issues/561