### PR TITLE
Set default workflow token permissions to read-only

### DIFF
--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -15,6 +15,9 @@ on:
     paths:
       - "Dockerfile*"
 
+permissions:
+  contents: read
+
 jobs:
   docker_buildx_alpine:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request applies the OSSF Scorecard **Token-Permissions** remedy.

It sets the default workflow token to read-only by adding a top-level `permissions` block to workflows that lacked one:

- `.github/workflows/build_latest.yml`

Any job that needs more than read access must be granted those permissions at the job level, otherwise it may fail.

See the [OSSF Scorecard guidance](https://github.com/AxisCommunications/github-governance/blob/main/ossf-scorecard/README.md#token-permissions) for details.